### PR TITLE
Spencer/feature/movie detail css

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -28,7 +28,7 @@ class App extends Component {
           <img src={img} alt="neatflix logo" className='neatflix-logo'></img>
         </header>
         {this.state.error && <h2>Something went wrong! {this.state.error.message}</h2>}
-        <MoviesContainer movies={this.state.allMovies}/>
+        <MoviesContainer className='movies-contaier' movies={this.state.allMovies}/>
       </main>
     )
   }

--- a/src/components/Movie_Detail/Movie_Detail.css
+++ b/src/components/Movie_Detail/Movie_Detail.css
@@ -1,0 +1,45 @@
+.movie-detail {
+  display: flex;
+  width: 90%;
+  height: 800px;
+  justify-content: space-evenly;
+  align-items: center;
+  margin-top: 20px;
+  margin-bottom: 20px
+}
+
+.poster {
+  height: 600px
+}
+
+.details {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 30%;
+  height: 40%;
+  padding: 20px;
+  color: white;
+  background-color: rgb(0, 0, 0, 0.7);
+  font-size: 40px;
+  border-radius: 10px;
+}
+
+button {
+  width: 40%;
+  height: 12%;
+  font-size: 20px;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  color: white;
+  background-color: rgb(167, 20, 28);
+  transition-duration: 400ms;
+}
+
+button:hover {
+  border: 1px solid #C2A031;
+  color: #C2A031;
+  transform: translateY(-.2em);
+  cursor: pointer;
+}

--- a/src/components/Movie_Detail/Movie_Detail.js
+++ b/src/components/Movie_Detail/Movie_Detail.js
@@ -1,12 +1,19 @@
-import React from "react";
-import MoviesContainer from "../Movies_Container/Movies_Container";
+import React from "react"
+import './Movie_Detail.css'
 
-const MovieDetail = ({movie, exitMovie}) => {
+const MovieDetail = ({ movie, exitMovie }) => {
+
+  const background = { backgroundImage: `url(${movie.backdrop_path})` }
+
   return (
-    <>
-      <p>{movie.id}</p>
-      <button onClick={() => exitMovie()}></button>
-    </>
+    <div className="movie-detail" style={background}>
+      <img src={movie.poster_path} alt={`poster for ${movie.title}`} className='poster'></img>
+      <div className="details">
+        <p>Title: {movie.title}</p>
+        <p>Rating: {movie.average_rating}</p>
+        <button onClick={() => exitMovie()}>Return</button>
+      </div>
+    </div>
   )
 }
 

--- a/src/components/Movies_Container/Movies_Container.css
+++ b/src/components/Movies_Container/Movies_Container.css
@@ -1,0 +1,3 @@
+.movies-container {
+  width: 100%
+}


### PR DESCRIPTION
#### What does this PR do?
This merge will add CSS to the movie detail view. 
- Background image set with `backdrop_path`, poster details with `poser_path`, and details showing `title` `average_rating`.
- `Return` button stylized with hover effect

#### What (if any) features are you implementing?
CSS

#### What (if anything) did you refactor?
In order to complete this task, I had to change the width of `movies_container` which will possible raise merge conflicts

#### Were there any issues that arose?
None.

#### Any other comments, questions, or concerns?
There are additional details not showing in the `movie_detail` view that will have to be refactored. I forgot to add `release_date`, and as discussed, will need to add in url path for previews, overview, budget, revenue, etc.

#### Screenshots
![image](https://user-images.githubusercontent.com/74210902/205474676-3fc61a9b-036e-49dc-b32a-225fb04cda97.png)
