### PR TITLE
Brett/refactor/various

### DIFF
--- a/cypress/e2e/moviedetail.cy.js
+++ b/cypress/e2e/moviedetail.cy.js
@@ -32,7 +32,7 @@ describe('Specific Movie Detail', () => {
   });
 
   it('Should show the release date', () => {
-    cy.contains('Release Date: 2020-09-29')
+    cy.contains('Release Date: September 29, 2020')
   });
 
   it('Should show the runtime', () => {
@@ -49,7 +49,7 @@ describe('Specific Movie Detail', () => {
 
   it('The background should be an image from the movie', () => {
     cy.get('.movie-detail')
-    .should('have.css', 'background-image', 'url("https://image.tmdb.org/t/p/original//pq0JSpwyT2URytdFG0euztQPAyR.jpg")')
+    .should('have.css', 'background-image', 'linear-gradient(rgba(54, 54, 54, 0.5), rgba(24, 24, 24, 0.67)), url("https://image.tmdb.org/t/p/original//pq0JSpwyT2URytdFG0euztQPAyR.jpg")')
   });
 
   it('Should show the movie poster', () => {

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -10,6 +10,8 @@ import '../Movie_Detail/Movie_Detail.css'
 import '../Search/Search.css'
 import '../Poster/Poster.css'
 import img from '../../Neatflix_Logos/2.png'
+import { Link } from 'react-router-dom'
+import { Redirect } from 'react-router-dom/cjs/react-router-dom.min'
 
 class App extends Component {
   constructor() {
@@ -75,7 +77,12 @@ class App extends Component {
             render={({ match }) => {
               if (!this.exactMatch(match.params.id)) {
                 return (
-                  <h1 className='warning'>Sorry, that link does not work!</h1>
+                  <>
+                    <h1 className='warning'>Sorry, that link does not work!</h1>
+                    <Link to={"/"}>
+                      <button>Home</button>
+                    </Link>
+                  </>
                 )
               }
               return (
@@ -86,6 +93,7 @@ class App extends Component {
               )
             }}
           />
+          <Redirect to='/' />
         </Switch>
       </main>
     )


### PR DESCRIPTION
#### What does this PR do?
- fixes cypress testing: when refactoring the DOM, it wasn't grabbing thins correctly but now it is again
- added a 'home' button in App to when user enters in wrong URL ID
- added a catch-all type `<Redirect />`  at the end of our router tree so that if the user enters anything that doesn't get caught by an error or by a bad ID will automatically go back to home. Found this was an issue when i typed ..'/[correct id]/somethingelsehere would not trigger our error message

#### What (if any) features are you implementing?
none

#### What (if anything) did you refactor?
Router

#### Were there any issues that arose?

#### Any other comments, questions, or concerns?

#### Screenshots (if applicable)
